### PR TITLE
Fix issue with importing sass-glob-import by updating version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "vite": "^4.0.0",
     "vite-plugin-external": "^1.2.7",
     "vite-plugin-handlebars": "^1.6.0",
-    "vite-plugin-sass-glob-import": "^1.4.0"
+    "vite-plugin-sass-glob-import": "^2.0.0"
   }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -37,6 +37,6 @@ export default defineConfig({
 				jquery: 'jQuery'
 			}
 		}),
-		sassGlobImports.default(),
+		sassGlobImports(),
 	],
 });


### PR DESCRIPTION
I just released version 2.0.0 of this plugin a couple days ago which provides full support for ESM. This seems to fix your issue.